### PR TITLE
Allow the user to define additional arguments into the phpunit command

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,4 +1,36 @@
 [
+{
+        "caption": "Preferences",
+        "mnemonic": "n",
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption": "PHPUnit",
+                        "children":
+                        [
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/PHPUnit/phpunit.sublime-settings"},
+                                "caption": "Settings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/User/phpunit.sublime-settings"},
+                                "caption": "Settings – User"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
     {
         "id": "tools",
         "caption": "Tools",

--- a/phpunit.py
+++ b/phpunit.py
@@ -112,6 +112,10 @@ class OutputView(object):
 class CommandBase:
     def __init__(self, window):
         self.window = window
+        # Load the settings files
+        self.settings_file = '%s.sublime-settings' % __name__
+        self.settings = sublime.load_settings(self.settings_file)
+        self.additional_args = self.settings.get('additional_args', {})
 
     def show_output(self):
         if not hasattr(self, 'output_view'):
@@ -141,13 +145,22 @@ class CommandBase:
 class PhpunitCommand(CommandBase):
     def run(self, path, testfile='', classname=''):
         self.show_empty_output()
+
         cmd = "cd '" + path[0] + "' && phpunit"
+
+        # Add the additional arguments from the settings file to the command
+        for key, value in self.additional_args.items():
+            cmd = cmd + " " + key
+            if value != "":
+                cmd = cmd + "=" + value
+
         if len(path) > 0:
             cmd = cmd + " -c '" + path[1] + "' "
         if testfile != '':
             cmd = cmd + " '" + testfile + "'"
         if classname != '':
             cmd = cmd + " '" + classname + "'"
+
         self.append_data(self, "$ " + cmd + "\n")
         self.start_async("Running PHPUnit", cmd)
 

--- a/phpunit.sublime-settings
+++ b/phpunit.sublime-settings
@@ -1,0 +1,24 @@
+{
+    // Additional arguments that can be supplied
+    //
+    // "key": "value"
+    //
+    // OR
+    //
+    // "key": "value"
+    //
+    // These values come from phpunit --help
+    //
+    // Example:
+    //
+    // "additional_args" :
+    // {
+    //  "--testdox": "",
+    //  "--coverage-html": "build/"
+    // }
+    //
+    "additional_args" :
+    {
+
+    }
+}


### PR DESCRIPTION
Hi Stuart,

I generally supply other arguments into the phpunit command on my terminal, so I've added the functionality to define those options in a configuration file..
