### PR TITLE
Need to access the items of the additional arguments

### DIFF
--- a/phpunit.py
+++ b/phpunit.py
@@ -164,7 +164,7 @@ class PhpunitCommand(CommandBase):
         args = ["phpunit"]
 
         # Add the additional arguments from the settings file to the command
-        for key, value in Prefs.phpunit_additional_args:
+        for key, value in Prefs.phpunit_additional_args.items():
             arg = key
             if value != "":
                 arg += "=" + value


### PR DESCRIPTION
Need to access the items of the additional arguments otherwise you get the following error:

Traceback (most recent call last):
  File "./sublime_plugin.py", line 350, in run_
  File "./phpunit.py", line 864, in run
  File "./phpunit.py", line 167, in run
ValueError: too many values to unpack
