### PR TITLE
A simple tweak to enable control over PHPUnit's execution environment, needed for projects that use getenv()

### DIFF
--- a/PHPUnit.sublime-settings
+++ b/PHPUnit.sublime-settings
@@ -4,5 +4,7 @@
     "max_search_secs": 2,
     "phpunit_xml_location_hints": [ "app" ],
     "phpunit_additional_args": {},
+    "copy_env": true,
+    "override_env": {},
     "debug": 0
 }


### PR DESCRIPTION
override_env: {"MYPROJECT_ENVIRONMENT": "test-myname-mydevbox"}
