### PR TITLE
Absolute path to the phpunit.xml.dist file.

### DIFF
--- a/phpunit.py
+++ b/phpunit.py
@@ -199,7 +199,7 @@ class PhpunitCommand(CommandBase):
 
         if len(path) > 0:
             args.append("-c")
-            args.append(path[1])
+            args.append(path[0] + "/" + path[1])
         if classname != '':
             args.append(classname)
         if testfile != '':


### PR DESCRIPTION
The plugin could find the phpunit.xml.dist file, but when I ran the
unittest it didn't find it, I made the path to the phpunit.xml.dist file
absolute.
