### PR TITLE
Able to run test file even if the class being tested is not found

### DIFF
--- a/phpunit.py
+++ b/phpunit.py
@@ -748,7 +748,7 @@ class PhpunitRunTestsCommand(PhpunitTextBase):
             test_file_to_open = self.find_test_file()
             tested_file_to_open = [self.view.file_name()]
 
-        if test_file_to_open is None or tested_file_to_open is None:
+        if test_file_to_open is None and tested_file_to_open is None:
             return False
 
         self.file_to_test = test_file_to_open[0]


### PR DESCRIPTION
After the recent update, Sublime-PHPUnit now able to run tests on both the test and the class file. But, if I open a test file and it's unable to detect where the class file is, I can't run the test. To me, I want to run the test file whether or not the class file exist, because sometimes my test file only test a bunch of functions or this extension just unable to detect the class file (the class file exists but it failed to detect it for some reason).
