### PR TITLE
Debug message raises TypeError when classname is None.

### DIFF
--- a/phpunit.py
+++ b/phpunit.py
@@ -558,7 +558,7 @@ class ActiveView(ActiveFile):
     def find_tested_file(self):
         Msgs.debug_msg("Looking for tested file")
         fq_classname = self.determine_full_class_name()
-        if not fq_classname or fq_classname is None:
+        if fq_classname is None:
             return None
         if fq_classname[-4:] == 'Test':
             fq_classname = fq_classname[:-4]


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "~\Sublime Text 3\sublime_plugin.py", line 442, in is_enabled_
    ret = self.is_enabled()
  File "~\Sublime Text 3\Data\Packages\sublime-phpunit\phpunit.py", line 939, in is_enabled
    filename = self.find_test_file()
  File "~\Sublime Text 3\Data\Packages\sublime-phpunit\phpunit.py", line 588, in find_test_file
    Msgs.debug_msg("classname is: " + classname)
TypeError: Can't convert 'NoneType' object to str implicitly
```
