### PR TITLE
Freeze fix: Disable building file list in root

### DIFF
--- a/phpunit.py
+++ b/phpunit.py
@@ -683,7 +683,7 @@ class ActiveWindow(ActiveFile):
 
     def is_php_buffer(self):
         ext = os.path.splitext(self.file_name())[1]
-        if ext == 'php':
+        if ext == '.php':
             return True
         return False
 


### PR DESCRIPTION
Hi, this pull should fix freeze from issue #37.
It can be reproduced by opening file outside opened folders and top_folder_hints and invoking context menu (or Sublime's command panel). 
