### PR TITLE
Toggle between Class.php and ClassTest.php with one shortcut

### DIFF
--- a/phpunit.py
+++ b/phpunit.py
@@ -199,13 +199,13 @@ class PhpunitCommand(CommandBase):
         # remove the folder from the configfile
         if configfile.startswith(folder):
             configfile = configfile[len(folder):]
-            if configfile[0] == "/":
+            if configfile[0] == os.path.sep:
                 configfile = configfile[1:]
 
         # remove the folder from the testfile
         if testfile.startswith(folder):
             testfile = testfile[len(folder):]
-            if testfile[0] == "/":
+            if testfile[0] == os.path.sep:
                 testfile = testfile[1:]
 
         if os.path.isfile(os.path.join(folder, configfile)):

--- a/phpunit.py
+++ b/phpunit.py
@@ -830,10 +830,13 @@ class PhpunitOpenTestClassCommand(PhpunitTextBase):
         if not self.is_php_buffer():
             return False
         if self.is_test_buffer() or self.is_tests_buffer():
-            return False
-        path = self.find_test_file()
-        if path is None:
-            return False
+            path = self.find_tested_file()
+            if path is None:
+                return False
+        else:
+            path = self.find_test_file()
+            if path is None:
+                return False
         self.file_to_open = path[0]
         return True
 


### PR DESCRIPTION
Hi,

I added two features:
- Use one shortcut to switch from Class.php to ClassTest.php and vice versa.
- Do a matching between the class and the file.

For example my class `micClass` is matching the file `miClass.php`. 
Therefore, I had two (facultative) entries in `PHPUnit.sublime-settings`

```
{
    "prefix_file": "mi",
    "prefix_class": "mic"
}
```

Hope, this could help.
